### PR TITLE
Dashboard prototype

### DIFF
--- a/dashboard/static/index.html
+++ b/dashboard/static/index.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
+  <title>The Dread Pirate Robots' Dashboard</title>
+  
+<style>
+body {
+  max-width: 800px;
+  margin-left: auto;
+  margin-right: auto;
+  font-family: sans-serif;
+}
+
+
+#topics-table {
+    margin: 0 auto;
+    border: 1px solid #ddd;
+    border-collapse: collapse;
+}
+
+#topics-table tr:nth-child(odd) {
+  background-color: #ddd;
+}
+
+#topics-table td {
+  min-width: 3em;
+  padding: 0.5em;
+}
+
+.overlay-box {
+    display: block;
+    position: fixed;
+    background-color: #b4cfea;
+    padding: 1em;
+    border: 1px solid black;
+    border-radius: 10px;
+    margin: 0px auto;
+    top: 1em;
+    left: 0px;
+    right: 0px;
+    width: 600px;
+    text-align: center;
+}
+</style>
+</head>
+
+<body role="document">
+  <div id="disconnected" class="overlay-box" style="display: none;">
+    Disconnected - refresh page when ROS is running to reconnect
+  </div>
+  <div id="connecting" class="overlay-box">
+    Connecting...
+  </div>
+  <table id='topics-table'>
+    <tr><td>/wind_direction_apparent</td><td id='value-wind_direction_apparent'></td></tr>
+    <tr><td>/rudder_control</td><td id='value-rudder_control'></td></tr>
+    <tr><td>/position</td><td id='value-position'></td></tr>
+  </table>
+
+<script>
+id = document.getElementById.bind(document)
+
+window.addEventListener("load", function(event) {
+  var ws = new WebSocket('ws://' + location.host + '/updates');
+  ws.onopen = function(event) {
+    id('connecting').style.display = 'none';
+  };
+  ws.onmessage = function(event) {
+    var json_msg = JSON.parse(event.data);
+    // substring(1) to strip off leading /
+    var e = id('value-' + json_msg.topic.substring(1));
+    if (!e) {
+      return;
+    }
+    while (e.firstChild) { e.removeChild(e.firstChild); }
+    var new_text;
+    if (json_msg.latitude !== undefined) {
+      var lat_hemi = json_msg.latitude > 0 ? 'N' : 'S';
+      var lon_hemi = json_msg.longitude > 0 ? 'E' : 'W';
+      new_text = String(Math.abs(json_msg.latitude)) + '° ' + lat_hemi + ' / '
+               + String(Math.abs(json_msg.longitude)) + '° ' + lon_hemi;
+    } else {
+      new_text = String(json_msg.value);
+    }
+    e.appendChild(new Text(new_text));
+  };
+  ws.onclose = function(event) {
+    id('disconnected').style.display = 'block';
+  };
+});
+</script>
+
+</body>
+</html>

--- a/src/sailing_robot/scripts/dashboard
+++ b/src/sailing_robot/scripts/dashboard
@@ -3,7 +3,6 @@
 import rospy
 from std_msgs.msg import Float32, Float64, Int16, String
 from sensor_msgs.msg import NavSatFix
-from sailing_robot.navigation import Navigation
 
 import json
 import os
@@ -66,7 +65,7 @@ class UpdateHandler(tornado.websocket.WebSocketHandler):
         json_msg = json.dumps(content)
         self.write_message(json_msg)
 
-def dashboard_server(nav):
+def dashboard_server():
     tornado.log.enable_pretty_logging()
     forwarder = MessageForwarder()
     app = tornado.web.Application([
@@ -87,8 +86,6 @@ def dashboard_server(nav):
 if __name__ == '__main__':
     try:
         rospy.init_node("serve_dashboard", anonymous=True)
-        nav = Navigation()
-        nav.subscribe_topics()
-        dashboard_server(nav)
+        dashboard_server()
     except rospy.ROSInterruptException:
         pass

--- a/src/sailing_robot/scripts/dashboard
+++ b/src/sailing_robot/scripts/dashboard
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+
+import rospy
+from std_msgs.msg import Float32, Float64, Int16, String
+import sailing_robot
+from sailing_robot.tasks import TasksRunner
+from sailing_robot.navigation import Navigation
+from sensor_msgs.msg import NavSatFix
+
+import json
+import os
+import tornado.ioloop
+import tornado.log
+import tornado.web
+import tornado.websocket
+
+PORT = 8448
+STATIC_PATH = os.path.expanduser('~/sailing-robot/dashboard/static')
+
+simple_topics = [
+    ('/heading', Float32),
+    ('/goal_heading', Float32),
+    ('/rudder_control', Int16),
+    ('/sailing_state', String),
+    ('/wind_direction_apparent', Float64),
+]
+
+geo_topics = [
+    '/position',
+]
+
+class MessageForwarder(object):
+    """Forward ROS messages to a websocket"""
+    def __init__(self):
+        self.sockets = []
+        for topic, rostype in simple_topics:
+            self.simple_forwarding(topic, rostype)
+        for topic in geo_topics:
+            self.geo_forwarding(topic)
+            
+    
+    def broadcast(self, content):
+        for s in self.sockets:
+            s.send_json_message(content)
+    
+    def simple_forwarding(self, topic_name, rostype):
+        def forward(msg):
+            self.broadcast({'topic': topic_name, 'value': msg.data})
+        return rospy.Subscriber(topic_name, rostype, forward)
+
+    def geo_forwarding(self, topic_name):
+        def forward(msg):
+            self.broadcast({'topic': topic_name, 'latitude': msg.latitude,
+                            'longitude': msg.longitude})
+        return rospy.Subscriber(topic_name, NavSatFix, forward)
+
+class UpdateHandler(tornado.websocket.WebSocketHandler):
+    def initialize(self, forwarder):
+        self.forwarder = forwarder
+    
+    def open(self):
+        self.forwarder.sockets.append(self)
+    
+    def on_close(self):
+        self.forwarder.sockets.remove(self)
+    
+    def send_json_message(self, content):
+        json_msg = json.dumps(content)
+        self.write_message(json_msg)
+
+def dashboard_server(nav):
+    tornado.log.enable_pretty_logging()
+    forwarder = MessageForwarder()
+    app = tornado.web.Application([
+        (r"/()", tornado.web.StaticFileHandler,
+            {"path": STATIC_PATH, "default_filename": "index.html"}),
+        (r"/updates", UpdateHandler,
+            {"forwarder": forwarder}),
+    ],
+    static_path=STATIC_PATH,
+    compiled_template_cache=False,
+    )
+    app.listen(PORT, address='0.0.0.0')
+    loop = tornado.ioloop.IOLoop.current()
+    rospy.client.on_shutdown(loop.stop)
+    loop.start()
+
+
+if __name__ == '__main__':
+    try:
+        rospy.init_node("serve_dashboard", anonymous=True)
+        nav = Navigation()
+        nav.subscribe_topics()
+        dashboard_server(nav)
+    except rospy.ROSInterruptException:
+        pass

--- a/src/sailing_robot/scripts/dashboard
+++ b/src/sailing_robot/scripts/dashboard
@@ -2,10 +2,8 @@
 
 import rospy
 from std_msgs.msg import Float32, Float64, Int16, String
-import sailing_robot
-from sailing_robot.tasks import TasksRunner
-from sailing_robot.navigation import Navigation
 from sensor_msgs.msg import NavSatFix
+from sailing_robot.navigation import Navigation
 
 import json
 import os


### PR DESCRIPTION
This is a very quick prototype of an idea I've had for #65. It opens up a lot more possibilities for better monitoring, but I think it will be useful already even in its present form.

The idea is to run a web server as a ROS node, and serve a live-updating HTML dashboard. Then anyone connected to the raspi wifi can monitor it in a browser by going to `(raspi ip address):8448`. There's no need to configure ROS for the network, or even install ROS on the computer you're monitoring from. With a bit of careful design, it should even be possible to monitor it from a phone.

Here it is running a dummy launch file on the VM - I was in the midst of changing how some other stuff works, so there weren't many topics available to view, but it should give the idea:

![dashboard-screenshot](https://cloud.githubusercontent.com/assets/327925/15837746/d8d48ca4-2c3a-11e6-8105-8d060a90e3cd.png)

If ROS goes down or it loses the connection, it makes it clear that the dashboard is no longer live:

![disconnected screenshot](https://cloud.githubusercontent.com/assets/327925/15837930/dbf3a0ae-2c3b-11e6-99b9-0e58bcf7e27f.png)

